### PR TITLE
Added first time run sanity checks and hints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+due (1.2.1) RELEASED; urgency=medium
+
+  * Added first time setup checks and hints.
+
+ -- Alex Doyle <alexddoyle@gmail.com>  Mon, 13 Apr 2020 18:21:55 -0700
+
 due (1.2.0) RELEASED; urgency=medium
 
   * Added --dockerarg to pass arguments directly to docker

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Build-Depends: debhelper (>= 9),
 	       git
 Standards-Version: 3.9.8
-Homepage: https://github.com/ehdoyle/DUE
+Homepage: https://github.com/CumulusNetworks/DUE
 
 Package: due
 Architecture: all

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -17,7 +17,7 @@ packages:
 If this is a Debian based Linux, like Ubuntu `sudo apt-get update; sudo apt-get install git docker.io` will handle this.  
 Once Docker is installed, add yourself to the docker group with:
 
-`sudo usermod -a -G docker $(whoami)`
+`sudo /usr/sbin/usermod -a -G docker $(whoami)`
 
 You will probably have to log out and back in for your new membership to take effect
 

--- a/due
+++ b/due
@@ -1083,6 +1083,22 @@ if [ "$DO_DEBUG" = "TRUE" ];then
 	set -x
 fi
 
+
+#
+# Check for user Docker group membership before any actions. 
+# They have to be a member for anything beyond this point
+# to work.
+#
+groups | grep -q "docker"
+if [ $? != 0 ];then
+	fxnWarn "You are not an active member of the Docker group."
+	echo " You can fix this by doing the following:"
+	echo "  1 - run: sudo /usr/sbin/usermod -a -G docker $(whoami)"
+	echo "  2 - log out and back in again for the addition to take effect."
+	echo ""
+	exit 1				
+fi
+
 #
 # if logging in to a running container
 #

--- a/libdue
+++ b/libdue
@@ -12,7 +12,13 @@
 # Enable extended pattern matching
 shopt -s extglob
 
-DUE_VERSION="1.2.0"
+DUE_VERSION="1.2.1"
+
+# Debian packages required for DUE to run
+REQUIRED_PACKAGES=" docker.io rsync bsdutils git"
+
+# Packages to support processor emulation (ARM builds, etc)
+RECOMMENDED_PACKAGES=" binfmt-support qemu qemu-user-static "
 
 # Get enough information to add the current user account to a container
 USER_NAME=$(whoami)
@@ -453,7 +459,12 @@ function fxnMakeNewDockerImage()
 		if [ -e /.dockerenv ];then
 			fxnERR "Docker not found, but you are already running in a container."
 		else
-			fxnERR "Docker not found! Try: sudo apt update ; sudo apt install docker. Exiting."
+			fxnERR "Docker not found! You should:"
+			echo "1 - Install with:                      sudo apt update ; sudo apt install $REQUIRED_PACKAGES "
+			echo "2 - Add yourself to the docker group:  sudo /usr/sbin/usermod -a -G docker $(whoami)"
+			echo "3 - Consider the recommended packages: sudo apt install $RECOMMENDED_PACKAGES "
+			echo "4 - Activate docker group membership:  log yourself out and log in again."
+			echo "Exiting."
 		fi
 		exit 1
 	fi
@@ -481,6 +492,10 @@ function fxnMakeNewDockerImage()
 		#
 		fxnHeader "Creating directory to be used for container build at: [ $imageName ]"
 		fxnPP "Copying non-template files from [ $USE_TEMPLATE_PATH ] to [ $imageName ]"
+		if [ ! -e /usr/bin/rsync ];then
+			fxnERR "rsync is not installed. Try: sudo apt update; sudo apt install rsync"
+			exit 1
+		fi
 		fxnEC rsync \
 			  --archive \
 			  --verbose \
@@ -1336,8 +1351,10 @@ function fxnCreateConfigFile()
 # Read any user set configuraton, and provide config file under ~/.config
 #
 
-# Save for later if printing --verbose . Default to using the system wide config file
-CONFIG_FILE_PATH="$DUE_CONFIG_FILE_PATH"
+# Save for later if printing --verbose.
+# Default to user's due.conf file
+CONFIG_FILE_PATH="$DUE_HOME_CONFIG_ABSOLUTE_PATH"
+
 function fxnReadConfigFile()
 {
 	# store variable name / value pairs
@@ -1345,29 +1362,37 @@ function fxnReadConfigFile()
 	local homeDir
 	local maxContainers
 	
-	if [ -e "$DUE_HOME_CONFIG_ABSOLUTE_PATH" ];then
-		# Unless the user has a local version...
-		CONFIG_FILE_PATH="$DUE_HOME_CONFIG_ABSOLUTE_PATH"
+	# If the user's local DUE config does not exist
+	if [ ! -e "$DUE_HOME_CONFIG_ABSOLUTE_PATH" ];then		
+		if [ -e "$CONFIG_FILE_PATH" ];then
+			# Use the system wide file if it exists ( via Debian package install)
+			CONFIG_FILE_PATH="$DUE_HOME_CONFIG_ABSOLUTE_PATH"
+		else
+			# Create a local config to use.
+			fxnPP "Creating DUE configuraton file at $CONFIG_FILE_PATH" 
+			fxnEC fxnCreateConfigFile || exit 1
+		fi
 	fi
 
-	# Read the file, filter out comments (#) and empty lines (\S)
-	configVars=$( grep -v "#" "$CONFIG_FILE_PATH" | grep "\S" )
+	if [ -e "$CONFIG_FILE_PATH" ];then
+		# Read the file, filter out comments (#) and empty lines (\S)
+		configVars=$( grep -v "#" "$CONFIG_FILE_PATH" | grep "\S" )
 
-	# Parse the DUE_ENV_DEFAULT_HOMEDIR variable.
-	homeDir=$(echo "$configVars" | grep DUE_ENV_DEFAULT_HOMEDIR | tail -n 1 )
-	if [ "$homeDir" != "" ];then
-		# This will set DUE_ENV_DEFAULT_HOMEDIR
-		eval "$( echo $homeDir )"			
-	fi
+		# Parse the DUE_ENV_DEFAULT_HOMEDIR variable.
+		homeDir=$(echo "$configVars" | grep DUE_ENV_DEFAULT_HOMEDIR | tail -n 1 )
+		if [ "$homeDir" != "" ];then
+			# This will set DUE_ENV_DEFAULT_HOMEDIR
+			eval "$( echo $homeDir )"			
+		fi
 
-	# Parse the DUE_USER_CONTAINER_LIMIT variable, and ovedrride the
-	# default set at the top of this file.
-	maxContainers=$(echo "$configVars" | grep DUE_USER_CONTAINER_LIMIT | tail -n 1 )
-	if [ "$maxContainers" != "" ];then
-	    # Trim everything before the = to leave the number
-	    DUE_USER_CONTAINER_LIMIT=${maxContainers##*=} 
+		# Parse the DUE_USER_CONTAINER_LIMIT variable, and ovedrride the
+		# default set at the top of this file.
+		maxContainers=$(echo "$configVars" | grep DUE_USER_CONTAINER_LIMIT | tail -n 1 )
+		if [ "$maxContainers" != "" ];then
+			# Trim everything before the = to leave the number
+			DUE_USER_CONTAINER_LIMIT=${maxContainers##*=} 
+		fi
 	fi
-	
 }
 
 # DUE embeds labels into the images it creates to get hints for how the containers should


### PR DESCRIPTION
Adding DUE to a fresh OS install provided the opportunity
to address a number of one-off, initial configuration issues
users may trip over, running it as a source code checkout.

Improvements include:

- debian/control file home page is official

- Updated the command to add user to group in GettingStarted.md.
 Usermod being under /usr/sbin always makes me think it's not
 installed because it is not in the path by default.

- Check for the invoking user to be in theDocker group before
 trying to invoke docker and then print commands to add them
 if they are not already in the group

- Print commands to add required packages
 if docker is not installed

- Create a user local config file if there isn't
 one under /etc (indicating this was a source
 download rather than a Debian package install.)
 ...and only try to read that file if it exists.
 This fixes a grep error message showing up.