### PR TITLE
Non interactive commands now return a return code

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+due (1.2.2~1)  UNRELEASED; urgency=medium
+
+  * Non interactive commands now return a return code
+
+ -- Alex Doyle <alexddoyle@gmail.com>  Fri, 24 Apr 2020 09:37:59 -0700
+
 due (1.2.1) RELEASED; urgency=medium
 
   * Added first time setup checks and hints.

--- a/libdue
+++ b/libdue
@@ -234,7 +234,7 @@ function fxnDeleteImage()
 
     docker images \
         | grep "$DELETE_TERM" \
-        | awk '{printf "# Delete: %s Tag: %s Imaage ID %s, Created %s %s %s, Size %s \n docker rmi --force %s \n", $1, $2, $3, $4, $5, $6, $7, $3}' \
+        | awk '{printf "# Delete: %s Tag: %s Image ID %s, Created %s %s %s, Size %s \n docker rmi --force %s \n", $1, $2, $3, $4, $5, $6, $7, $3}' \
               >> "$DELETE_SCRIPT"
 
 

--- a/templates/common-templates/filesystem/usr/local/bin/container-create-user.sh
+++ b/templates/common-templates/filesystem/usr/local/bin/container-create-user.sh
@@ -234,6 +234,8 @@ function fxnRunAsUser()
 		echo "| Done   [ $COMMAND_LIST ]"
 		echo "| Status [ $result ]"
         echo "|___________________________________________________________________________|"
+		# Make sure the result of the command is returned
+		return $result
     else
         echo "|                                                                           |"		
         echo "| Container log in text follows:                                            |"

--- a/templates/onie/README.md
+++ b/templates/onie/README.md
@@ -5,9 +5,9 @@ Create ONIE build environments using a Debian 8 (Jessie) or Debian 9 (Stretch) i
 Currently Debian 10 (and related releases) aren't supported by ONIE.  
 
 ## ONIE build environment creation example
-Create latest default ONIE build environment with: ./due --create --from debian:9  --description "ONIE Build Debian 9" --name onie-build --prompt ONIE --tag onie --use-template onie  
+Create latest default ONIE build environment with: ./due --create --from debian:9  --description "ONIE Build Debian 9" --name onie-build-debian-9 --prompt ONIE-9 --tag onie --use-template onie  
 **OR**  
-Create Debian 8 ONIE build environment with: ./due --create --from debian:8  --description "ONIE Build Debian 8" --name onie-build-8 --prompt ONIE-8 --tag onie-8 --use-template onie
+Create Debian 8 ONIE build environment with: ./due --create --from debian:8  --description "ONIE Build Debian 8" --name onie-build-debian-8 --prompt ONIE-8 --tag onie-8 --use-template onie
 ### Explanation of the first example:
   * Use a Debian 9 image
   * Name it onie-build


### PR DESCRIPTION
Fixes a bug where any non-interactive command would return 0.
Found this doint ONIE automation where everything 'worked' without
producing binares.

Set recommended ONIE container creation names to have debian-<vers>
in them to make it easier for automation to follow a pattern and
find them.

Fixed typo in image delete script.