### PR TITLE
Update duebuild documentation, debian package duebuild fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,9 @@ due (2.0.0-1) unstable; urgency=medium
   * debian-package: Set ulimit -n 10000 for slow Apt on Jessie images
   * debian-package: Install python version based on image Debian release
   * debian-package: Clean up files generated when resolving build dependencies
+  * debian-package: Keep current package configuration on packag upgrades
+  * debian-package: Absolute path option for local package repository
+  * debian-package: Don't error out if no dependencies need to be installed.
   * libdue for emulation, qemu-<arch>-static comes from source image's arch
   * due: do not filter images after --run-image has been invoked.
   * due: add --delete option

--- a/templates/common-templates/duebuild-readme.md
+++ b/templates/common-templates/duebuild-readme.md
@@ -1,0 +1,94 @@
+This file is a starting point for documenting the particulars of a container's duebuild script.  
+See the debian-package version for what this might look like in practice.
+
+# Duebuild for building REPLACE
+
+The `duebuild` script handles setup and build for whatever target
+the contiainer supports. As such this will vary from container to
+container, but there are a set of standard arguments it is expected
+to support defined by `common-templates/filesystem/usr/local/bin/duebuild`
+
+
+# Workflow
+
+This script is invoked by using the `--build` argument when running `due`.  
+**Example:** build foo from source
+`cd ./foo`
+`due --build`
+
+
+# Script help
+The options for the REPLACE version of duebuild are printed below.  
+
+To print the duebuild help for any build container without logging in to it, run:  
+`due `--duebuild `--help  (select container)`
+
+## duebuild --help  
+**Usage**  : `duebuild: [--default|--cbuild|--build-dsc|--build-command]`  
+  This script is a default run target for due `--build`.
+  It performs build environment configuration before running one of the  
+  build target commands.  
+
+  **Build target commands.**  
+      `--default`                Build with default settings: dpkg-buildpackage -uc -us -j(max)  
+   `-c|--cbuild (args)`          Supply (args) to dpkg-buildpackage. If no args, build with defaults.
+                                   This must be the last argument on the line as everything after is passed.  
+      `--build-command (args)`   Do environment prep and run (args). Must be last argument on the line.  
+      `--help-build-targets`     More detailed description of the above options.  
+  
+  **Build options:**  
+   `-j|--jobs (#)`               Number of parallel builds to use. Defaults to the number of CPU cores.  
+   `--use-directory (dir)`       cd to (dir) before trying to build.  
+   `--prebuild-script (scr)`     Run script at container path (scr) before starting build. Pass 'NONE' to ignore.  
+   `--script-debug`              Enable -x if passed as first argument.  
+  
+  **REPLACE build options:**  
+  
+  **More information:**  
+   `--quiet`                    Suppress output.  
+   `--verbose`                  More info.  
+   `--help`                     This message  
+   `--help-examples`            Print possible configurations.  
+   `--version`                  Version of this script.  
+
+ 
+## duebuild `--help-build-targets`  
+  
+duebuild use examples for specifying how to build Debian packages.  
+  
+In all these examples, duebuild will:  
+ - REPLACE WITH DEFAULT SETUP 
+ - And then apply the build command.  
+  
+ **Examples:**  
+  DUE command:   `due --build`  
+  duebuild runs: `duebuild --default` 
+  Build command:  REPLACE  
+
+  DUE command:   `due --build --cbuild`  
+  duebuild runs: `duebuild --cbuild`  
+  Build command:  REPLACE  
+
+  DUE command:   `due --build --cbuild REPLACE WITH EXAMPLE ARGUMENTS`  
+  duebuild runs: duebuild `--cbuild REPLACE WITH EXAMPLE ARGUMENTS`  
+  Build command: REPLACE  
+    
+  DUE command:   `due --build --build-command make all`  
+  duebuild runs: duebuild --build-command make all  
+  Build command: make all  
+  
+
+## duebuild `--help-examples`  
+
+duebuild examples of additional build options.  
+
+** Examples: **
+
+  Build.
+   `./duebuild --cbuild` 
+  
+  Build default - a simple/standard build case.  
+   `./duebuild --cbuild --default`  
+  Pass additional arguments to build.  
+   `./duebuild --cbuild  REPLACE_THIS` build example  
+

--- a/templates/common-templates/filesystem/usr/local/bin/duebuild
+++ b/templates/common-templates/filesystem/usr/local/bin/duebuild
@@ -6,6 +6,9 @@
 #
 #  SPDX-License-Identifier:     MIT
 
+# Have last command in a pipe to fail return error code.
+# This prevents use of tee from hiding fails.
+set -o pipefail
 
 # Set top level directory to be where we are now
 if [ "$gTOP_DIR" = "" ];then
@@ -81,22 +84,21 @@ function fxnMSG ()
 
 function fxnHelp()
 {
-    echo "Usage  : $(basename "$0"): [--cbuild|--source --type-arch-debs --type-all-debs ] <name>"
-    echo "  This script mimics sbuild with a few additional arguments."
+    echo "Usage  : $(basename "$0"): [options] [--cbuild | --default | --build-command <args> ]"
+    echo "  Script to support building for the container's target."
     echo ""
     echo "  Build targets:"
     echo "   -c|--cbuild <args>          Default container build REPLACE_THIS build instructions"
 	echo "                               <args> is a list of additional build commands. Must be last argument."
 	echo "      --default                Try to build with default settings."
+    echo "      --build-command <args>   Do environment prep and run <args>. Must be last argument on the line."
+    echo "      --help-build-targets     More detailed description of the above options."	
     echo ""
     echo "  Build options:"
-    echo "   -j|--jobs <#>               Number of parallel builds to use."
-    echo "   --build-attempts <times>    Try to build this many times. Default is [ $BUILD_ATTEMPTS ]"	
+    echo "   -j|--jobs <#>               Number of parallel builds to use. Defaults to the number of CPU cores."
     echo "   --use-directory <dir>       cd to <dir> before trying to build."
     echo "   --prebuild-script <scr>     Run script at container path <scr> before starting build. Pass 'NONE' to ignore."
-    echo "   --version                   Print version"
     echo "   --script-debug              Enable -x if passed as first argument."
-
     echo ""
     echo ""
     echo "  More information:"
@@ -104,9 +106,41 @@ function fxnHelp()
     echo "   --verbose                  More info."
     echo "   --help                     This message"
     echo "   --help-examples            Print possible configurations."
+    echo "   --version                  Version of this script."
     echo ""
 }
 
+#
+# A more detailed breakdown on what exactly gets run with which option.
+#
+function fxnHelpBuildTargets()
+{
+    echo ""
+    echo "duebuild use examples for specifying how to build REPLACE_WITH_TARGET"
+    echo ""
+	echo "In all these examples, duebuild will:"
+	echo " - REPLACE WITH ANY PRECONFIGURATION"
+	echo " - And then apply the build command."
+	echo ""
+	echo " Examples"
+    echo "  DUE command:   due --build"
+    echo "  duebuild runs: duebuild --default"
+    echo "  Build command: REPLACE"
+    echo ""
+    echo "  DUE command:   due --build --cbuild"
+    echo "  duebuild runs: duebuild --cbuild"
+    echo "  Build command: REPLACE"
+    echo ""
+    echo "  DUE command:   due --build --cbuild REPLACE WITH EXAMPLE ARGUMENTS"
+    echo "  duebuild runs: duebuild --cbuild REPLACE WITH EXAMPLE ARGUMENTS"
+    echo "  Build command: REPLACE"
+    echo ""
+    echo "  DUE command:   due --build --build-command make all"
+    echo "  duebuild runs: duebuild --build-command make all"
+    echo "  Build command: make all"
+    echo ""
+	
+}	
 # Demonstrate cases of script usage
 function fxnHelpExamples()
 {
@@ -153,6 +187,11 @@ function fxnPrintConfig()
     echo "| Invoked with:      $INVOKED_WITH"
     if [ "$DO_DEFAULT" != "" ];then
         echo "| Building with default settings"
+    fi
+    if [ "$RAW_BUILD_COMMAND" != "" ];then
+        echo "| build command:     $RAW_BUILD_COMMAND"
+    else
+        echo "| build command:      REPLACE"
     fi	
     echo "|"
     echo "| Build dir            [ $(pwd) ]"
@@ -170,7 +209,7 @@ function fxnPrintConfig()
 
 
 
-# Function to replace sbuild
+# Function to build whatever the target is
 function fxnDoBuild()
 {
 
@@ -181,6 +220,20 @@ function fxnDoBuild()
         echo ""
 
         # And BUILD_ARGS was set
+
+		if [ "$RAW_BUILD_COMMAND" != "" ];then
+            failMsg="$RAW_BUILD_COMMAND failed with error "
+            fxnMSG "Building in [ $(pwd) ] with [ $RAW_BUILD_COMMAND ].  Attempt [ $BUILD_ATTEMPTS ]. "
+			# Run a non-default build command after setup
+            echo "bash -c  $RAW_BUILD_COMMAND"
+            bash -c " $RAW_BUILD_COMMAND"
+        else
+            failMsg="dpkg-buildpackage $BUILD_ARGS failed with error "
+            fxnMSG "Building in [ $(pwd) ] with [ $BUILD_ARGS ].  Attempt [ $BUILD_ATTEMPTS ]. "
+            # And ADDITIONAL_BUILD_ARGS was set
+            echo "bash -c  'default build command goes here'"
+			#  bash -c " default build command "
+        fi
 
         bash -c " echo 'Build command goes here in duebuild script.'"
         result="$?"
@@ -203,7 +256,6 @@ function fxnDoBuild()
 
 
     fxnMSG "Built [ $BUILD_TARGET_DIR_NAME ] - list follows:"
-    # use grep to avoid errors when no .debs found
 
     echo ""
 }
@@ -237,6 +289,10 @@ if [ "$#" = "0" ];then
     fxnHelp
     exit 0
 fi
+
+# Track this. --jobs and -j* by themselves don't count as a non-default
+#  build command.
+TOTAL_COMMAND_LINE_ARGS="$#"
 
 #
 # Gather arguments and set action flags for processing after
@@ -274,6 +330,20 @@ do
 			fi
             ;;
 
+        --build-command )
+            # Default to build everything in container context
+            DO_BUILD="TRUE"
+            if [ "$2" != "" ];then
+                # More arguments?
+                # skip over --build-command
+                shift
+                # The rest of the arguments passed should be given verbatim to
+                # whatever the build command is.
+                RAW_BUILD_COMMAND="$*"
+            fi
+            break
+            ;;
+		
 		--default )
 			DO_DEFAULT="TRUE"
 			# --default is an exported hook that can be be called by DUE 
@@ -288,6 +358,11 @@ do
         -j* )
             # number of build job threads
             BUILD_JOBS="${term#-j}"
+            # If only jobs were specified, do default build
+            if [ "$TOTAL_COMMAND_LINE_ARGS" = 1 ];then
+                DO_DEFAULT="TRUE"
+                DO_BUILD="TRUE"
+            fi
             ;;
 
         --jobs )
@@ -296,6 +371,11 @@ do
             if [ "$2" = "" ];then
                 fxnERR "--jobs requires a #"
                 exit 1
+            fi
+            # If only jobs were specified, do default build
+            if [ "$TOTAL_COMMAND_LINE_ARGS" = 2 ];then
+                DO_DEFAULT="TRUE"
+                DO_BUILD="TRUE"
             fi
             shift
             ;;
@@ -338,11 +418,19 @@ do
             exit 0
             ;;
 
+        --help-build-targets)
+            # Examples of what gets invoked for each build option.
+            fxnHelpBuildTargets
+            exit 0
+            ;;
+
         --verbose )
+            # Unused for now
             DO_VERBOSE="TRUE"
             ;;
 
         --quiet )
+            # Unused for now
             DO_QUIET="TRUE"
             ;;
 
@@ -368,7 +456,8 @@ fi
 if [ "$DO_BUILD" = "TRUE" ];then
 
     if [ "$ADDITIONAL_BUILD_ARGS" != "" ];then
-        # User is overriding defaults to dpkg-buildpackage
+        # User is overriding defaults.
+        # take it literally with no defaults.
         BUILD_ARGS="$ADDITIONAL_BUILD_ARGS"
     fi
 
@@ -411,11 +500,20 @@ if [ "$DO_BUILD" = "TRUE" ];then
 
     fxnPP "Building with dev version $DEV_PACKAGE_VERSION"
     fxnDoBuild  2>&1 | tee -a  "$BUILD_LOG_FILE"
-    
+fi    
 
-    # Preserve exit code through exit trap
-    RETURN_CODE=${PIPESTATUS[0]}
+# Preserve exit code through exit trap
+RETURN_CODE=${PIPESTATUS[0]}
 
-    exit "$RETURN_CODE"
 
-fi
+
+
+if [ "$RETURN_CODE" = "0" ];then
+        fxnPP "Success"
+		# Add post build actions
+        fxnPP "Build finished at [ $(date) ]"
+else
+    fxnERR "Build FAILED with return code [ $RETURN_CODE ] at [ $(date) ]"
+
+
+exit "$RETURN_CODE"

--- a/templates/debian-package/duebuild-readme.md
+++ b/templates/debian-package/duebuild-readme.md
@@ -1,0 +1,149 @@
+# Duebuild for building Debian packages.
+
+The `duebuild` script handles setup and build for whatever target
+the contiainer supports. As such this will vary from container to
+container, but there are a set of standard arguments it is expected
+to support defined by `common-templates/filesystem/usr/local/bin/duebuild`
+
+
+# Workflow
+
+This script is invoked by using the `--build` argument when running `due`.  
+**Example:** build package foo from source
+`cd ./foo`
+`due --build`
+
+**Example:** build package foo from foo.dsc
+`due --build --build-dsc foo.dsc`
+
+# Script help
+The options for the Debian package version of duebuild are printed below.  
+
+To print the duebuild help for any build container without logging in to it, run:  
+`due `--duebuild `--help  (select container)`
+
+## duebuild --help  
+**Usage**  : `duebuild: [--default|--cbuild|--build-dsc|--build-command]`  
+  This script is a default run target for due `--build`.
+  It performs build environment configuration before running one of the  
+  build target commands.  
+
+  **Build target commands.**  
+      `--default`                Build with default settings: dpkg-buildpackage -uc -us -j(max)  
+   `-c|--cbuild (args)`          Supply (args) to dpkg-buildpackage. If no args, build with defaults.
+                                   This must be the last argument on the line as everything after is passed.  
+      `--build-command (args)`   Do environment prep and run (args). Must be last argument on the line.  
+      `--help-build-targets`     More detailed description of the above options.  
+      `--build-dsc (.dsc file)`  Build from debian source control file .dsc and associated tar.gz.  
+  
+  **Build options:**  
+   `-j|--jobs (#)`               Number of parallel builds to use. Defaults to the number of CPU cores.  
+   `--use-directory (dir)`       cd to (dir) before trying to build.  
+   `--prebuild-script (scr)`     Run script at container path (scr) before starting build. Pass 'NONE' to ignore.  
+   `--script-debug`              Enable -x if passed as first argument.  
+  
+  **Debian package build options:**  
+   `--skip-tests`                Define DEB_BUILD_OPTIONS=nocheck before build.  
+   `--deb-build-option (opt)`    Add 'opt' to DEB_BUILD_OPTIONS. Use once per option.  
+   `--build-attempts (times)`    Try to build this many times. Default is [ 1 ]  
+   `--dev-version (vers)`        Insert string into changelog package version for pre-release builds.
+                                  Note: you need to supply the leading ~ or +  
+   `--just-dev-version`          Exit after `--dev-version` applies  
+   `--set-git-hash `             If building type Git, do not autodiscover, use passed hash.  
+   `--source-date-epoch (d)`     Force the creation time of files, via date +%s. Otherwise defaults to now.  
+   `--source-format-one`         Clear git source history from package and set source to build as 1.0  
+   `--install-debs-dir (dir)`    Install all debs from (absolute path in container dir) before build.  
+   `--add-sources-list (file)`   Container relative path to include sources.list in build dir.  
+   `--use-local-repo (repo)`     Create a local package repository named (repo) to store and serve packages.  
+                                If (repo) starts with a '/' it will be treated as a container-relative  
+                                path for the location of the repository. Otherwise it defaults to the  
+                                directory above the build area.  
+  
+  **More information:**  
+   `--quiet`                    Suppress output.  
+   `--verbose`                  More info.  
+   `--help`                     This message  
+   `--help-examples`            Print possible configurations.  
+   `--version`                  Version of this script.  
+
+ 
+## duebuild `--help-build-targets`  
+  
+duebuild use examples for specifying how to build Debian packages.  
+  
+In all these examples, duebuild will:  
+ - Upgrade the container's packages.  
+ - Install the package's build dependencies.  
+ - And then apply the build command.  
+  
+ **Examples:**  
+  DUE command:   `due --build`  
+  duebuild runs: `duebuild --default` 
+  Build command: dpkg-buildpackage -uc -us -j(max)  
+  Note: to get the same outcome from the command line, run:  
+    due `--run --command sudo apt-get update \; sudo apt-get upgrade \; sudo mk-build-deps --install --remove ./debian/control --tool 'apt-get -y' \; dpkg-buildpackage -uc -us -j(max)`  
+  
+  DUE command:   `due --build --cbuild`  
+  duebuild runs: duebuild `--cbuild`  
+  Build command: dpkg-buildpackage-uc -us -j(max)  
+  
+  DUE command:   `due --build --cbuild -b`  
+  duebuild runs: duebuild --cbuild -b`  
+  Build command: dpkg-buildpackage-b -j(max)  
+  
+  DUE command:   `due --build --build-command make all`  
+  duebuild runs: duebuild --build-command make all  
+  Build command: make all  
+  
+
+## duebuild `--help-examples`  
+
+duebuild examples of additional build options.  
+
+  `--cbuild` passes whatever args are after it directly to dpkg-buildpackage.  
+  The following pulls from the dpkg-buildpackage man pages for two different versions.  
+
+  So for example:  
+  **--cbuild examples**. (versions earlier than 1.18.5, found in Jessie 8.)  
+   ./duebuild `--cbuild takes:  
+     -A - architecture independent (type 'all')  
+     -B - architecture dependent (amd64, armel, etc)  
+     -S - source only.  
+     -b - architecture dependent, independent, and no source.  
+  
+  **--cbuild examples**. (versions later than 1.18.5, found in Stretch 9 + )  
+   ./duebuild --cbuild --build= takes as , separated list:  
+     all    - architecture independent (type 'all')  
+     any    - architecture dependent (amd64, armel, etc)  
+     source - source only.  
+     binary - architecture dependent, independent, and no source.  
+     full   - build everything = source,any,all.  
+    So to build all binaries, no source:  
+    ./duebuild `--cbuild  `--build=any,all  
+  
+  Build source, arch specific and type 'all' (default -uc -us)  
+   `./duebuild --cbuild`  
+
+  Insert a string into the version  
+   `./duebuild --cbuild --dev-version ~1234`  
+
+  Set DEB_BUILD_OPTIONS values:  
+   `./duebuild --cbuild --deb-build-option debug --deb-build-option nostrip`  
+  
+  Store build products in a repository above the build directory for future builds  
+  (i.e. building things that need other things built to build...)  
+   `./duebuild --cbuild --use-local-repo myLocalRepo`  
+   Or specify that repository with an absolute (container relative) path:  
+   `./duebuild --cbuild --use-local-repo /path/to/myLocalRepo`   
+
+  Do environmental setup and run dpkg-buildpackage -uc -us -j8  
+   `./duebuild --build-command dpkg-buildpackage -uc -us -j8`  
+
+  Examples from DUE:  
+   Build package with 'nostrip' and 'debug' options,   
+   unsigned source, unsinged changes file, build binary, 5 jobs,  
+   and reference local package repository 'myLocalRepo'  
+     due `--build `--jobs 5 `--deb-build-option nostrip   
+     --deb-build-option debug `--use-local-repo myLocalRepo   
+     --cbuild -us -uc -b`  
+     

--- a/templates/debian-package/filesystem/usr/local/bin/duebuild
+++ b/templates/debian-package/filesystem/usr/local/bin/duebuild
@@ -85,19 +85,28 @@ function fxnMSG ()
 
 function fxnHelp()
 {
-    echo "Usage  : $(basename "$0"): [--cbuild|--source --type-arch-debs --type-all-debs ] <name>"
-    echo "  This script mimics sbuild with a few additional arguments."
+    echo""
+    echo "Usage  : $(basename "$0"): [--default|--cbuild|--build-dsc|--build-command] <name>"
+    echo "  This script is a default run target for due --build."
+    echo "  It performs build environment configuration before running one of the "
+    echo "  build target commands. "
     echo ""
-    echo "  Build targets:"
-    echo "   -c|--cbuild <args>          <args> takes the rest of the command line and passes it"
-    echo "                               to dpkg-buildpackage. Must be the last argument on the line."
-    echo "      --build-dsc <.dsc file>  Build from debian source control file .dsc and associated tar.gz"
-    echo "      --default                Try to build with default settings."
+    echo "  Build target commands."
+    echo "      --default                Build with default settings: dpkg-buildpackage -uc -us -j<max>"
+    echo "   -c|--cbuild <args>          Supply <args> to dpkg-buildpackage. If no args, build with defaults."
+    echo "                               This must be the last argument on the line as everything after is passed."
     echo "      --build-command <args>   Do environment prep and run <args>. Must be last argument on the line."
+    echo "      --help-build-targets     More detailed description of the above options."
+    echo "      --build-dsc <.dsc file>  Build from debian source control file .dsc and associated tar.gz."
     echo ""
     echo "  Build options:"
-    echo "   -j|--jobs <#>               Number of parallel builds to use."
-    echo "   --skip-tests                define DEB_BUILD_OPTIONS=nocheck before build."
+    echo "   -j|--jobs <#>               Number of parallel builds to use. Defaults to the number of CPU cores."
+    echo "   --use-directory <dir>       cd to <dir> before trying to build."
+    echo "   --prebuild-script <scr>     Run script at container path <scr> before starting build. Pass 'NONE' to ignore."
+    echo "   --script-debug              Enable -x if passed as first argument."
+    echo ""
+    echo "  Debian package build options:"
+    echo "   --skip-tests                Define DEB_BUILD_OPTIONS=nocheck before build."
     echo "   --deb-build-option <opt>    Add 'opt' to DEB_BUILD_OPTIONS. Use once per option."
     echo "   --build-attempts <times>    Try to build this many times. Default is [ $BUILD_ATTEMPTS ]"
     echo "   --dev-version <vers>        Insert string into changelog package version for pre-release builds."
@@ -105,33 +114,66 @@ function fxnHelp()
     echo "   --just-dev-version          Exit after --dev-version applies"
     echo "   --set-git-hash              If building type Git, do not autodiscover, use passed hash."
     echo "   --source-date-epoch <d>     Force the creation time of files, via date +%s. Otherwise defaults to now."
-
     echo "   --source-format-one         Clear git source history from package and set source to build as 1.0"
     echo "   --install-debs-dir <dir>    Install all debs from <absolute path in container dir> before build."
-    echo "   --use-directory <dir>       cd to <dir> before trying to build."
-
-
-    echo "   --prebuild-script <scr>     Run script at container path <scr> before starting build. Pass 'NONE' to ignore."
     echo "   --add-sources-list <file>   Container relative path to include sources.list in build dir."
     echo "   --use-local-repo <repo>     Create a local package repository named <repo> to store and serve packages."
-    echo "   --version                   Print version"
-    echo "   --script-debug              Enable -x if passed as first argument."
-
-    echo ""
+    echo "                                If <repo> starts with a '/' it will be treated as a container-relative"
+    echo "                                path for the location of the repository. Otherwise it defaults to the"
+    echo "                                directory above the build area."
     echo ""
     echo "  More information:"
     echo "   --quiet                    Suppress output."
     echo "   --verbose                  More info."
     echo "   --help                     This message"
     echo "   --help-examples            Print possible configurations."
+    echo "   --version                  Version of this script."
     echo ""
 }
 
+#
+# A more detailed breakdown on what exactly gets run with which option.
+#
+function fxnHelpBuildTargets()
+{
+    echo ""
+    echo "duebuild use examples for specifying how to build Debian packages."
+    echo ""
+    echo "In all these examples, duebuild will:"
+    echo " - Upgrade the container's packages."
+    echo " - Install the package's build dependencies."
+    echo " - And then apply the build command."
+    echo ""
+    echo " Examples:"
+    echo "  DUE command:   due --build"
+    echo "  duebuild runs: duebuild --default"
+    echo "  Build command: dpkg-buildpackage -uc -us -j<max>"
+    echo "  Note: to get the same outcome from the command line, run:"
+    echo "    due --run --command sudo apt-get update \; sudo apt-get upgrade \; sudo mk-build-deps --install --remove ./debian/control --tool 'apt-get -y' \; dpkg-buildpackage -uc -us -j<max>"
+
+    echo ""
+    echo "  DUE command:   due --build --cbuild"
+    echo "  duebuild runs: duebuild --cbuild"
+    echo "  Build command: dpkg-buildpackage-uc -us -j<max>"
+    echo ""
+    echo "  DUE command:   due --build --cbuild -b"
+    echo "  duebuild runs: duebuild --cbuild -b"
+    echo "  Build command: dpkg-buildpackage-b -j<max>"
+    echo ""
+    echo "  DUE command:   due --build --build-command make all"
+    echo "  duebuild runs: duebuild --build-command make all"
+    echo "  Build command: make all"
+    echo ""
+    echo ""
+
+
+}
 # Demonstrate cases of script usage
 function fxnHelpExamples()
 {
     echo ""
-    echo " Examples:"
+    echo "duebuild examples of Debian package build options."
+    echo ""
     echo "  --cbuild passes whatever args are after it directly to dpkg-buildpackage."
     echo "  The following pulls from the dpkg-buildpackage man pages for two different versions."
     echo ""
@@ -162,16 +204,18 @@ function fxnHelpExamples()
     echo "  Set DEB_BUILD_OPTIONS values:"
     echo "   $0 --cbuild --deb-build-option debug --deb-build-option nostrip "
     echo ""
-    echo "  Store build products in a repository for future builds"
+    echo "  Store build products in a repository above the build directory for future builds"
     echo "  (i.e. building things that need other things built to build...)"
     echo "   $0 --cbuild --use-local-repo myLocalRepo "
+    echo "   Or specify that repository with an absolute (container relative) path:"
+    echo "   $0 --cbuild --use-local-repo /path/to/myLocalRepo "
     echo ""
     echo "  Do environmental setup and run dpkg-buildpackage -uc -us -j8"
     echo "   $0 --build-command dpkg-buildpackage -uc -us -j8"
     echo ""
     echo "  Examples from DUE:"
     echo "   Build package with 'nostrip' and 'debug' options, "
-    echo "   unsigned source, unsinged changes file, build binary, 5 jobs,"
+    echo "   unsigned source, unsigned changes file, build binary, 5 jobs,"
     echo "   and reference local package repository 'myLocalRepo'"
     echo "     due --build --jobs 5 --deb-build-option nostrip "
     echo "     --deb-build-option debug --use-local-repo myLocalRepo "
@@ -609,7 +653,7 @@ function fxnDoDebianBuild()
     #
     rm -f due-build-deps_*.buildinfo
     rm -f due-build-deps_*.changes
-    
+
     #
     # If setting source to 1.0 for universal rebuild
     #
@@ -889,8 +933,8 @@ do
             shift
             ;;
 
-		# take --build as it tends to get typed in container
-		# --cbuild is clearer when invoking from outside the container
+        # take --build as it tends to get typed in container
+        # --cbuild is clearer when invoking from outside the container
         -c | --cbuild | --build )
             # Default to build everything in container context
             DO_BUILD="TRUE"
@@ -1055,13 +1099,19 @@ do
             exit 0
             ;;
 
+        --help-build-targets)
+            # Examples of what gets invoked for each build option.
+            fxnHelpBuildTargets
+            exit 0
+            ;;
+
         --verbose )
-	    # Unused for now
+            # Unused for now
             DO_VERBOSE="TRUE"
             ;;
 
         --quiet )
-	    # Unused for now
+            # Unused for now
             DO_QUIET="TRUE"
             ;;
 
@@ -1091,9 +1141,9 @@ if [ "$version" != "" ];then
     fxnMSG "Jessie era dpkg detected. Updating arguments."
     USE_JESSIE_DPKG="TRUE"
 
-	# Jessie apt has a bug where it tries to close 100K plus files in the shell.
-	# Set bash ulimit to max at 10000 to speed this up.
-	ulimit -n 10000
+    # Jessie apt has a bug where it tries to close 100K plus files in the shell.
+    # Set bash ulimit to max at 10000 to speed this up.
+    ulimit -n 10000
 fi
 
 # Arguments passed to the dpkg build. This gets

--- a/templates/debian-package/filesystem/usr/local/bin/duebuild
+++ b/templates/debian-package/filesystem/usr/local/bin/duebuild
@@ -460,12 +460,21 @@ function fxnUseLocalPackageRepository()
         useArchitecture=$( dpkg-architecture --query DEB_TARGET_ARCH )
     fi
 
-    LOCAL_PACKAGE_REPOSITORY_PATH=$( realpath "${BUILD_DIR}/.." )
-    echo "Using path $LOCAL_PACKAGE_REPOSITORY_PATH"
+    #
+    # Is the repository given as an absolute path?
+    # (it starts with a '/' ?)
+    if [[ $repoName == /* ]];then
+        # An absolute path
+        LOCAL_PACKAGE_REPOSITORY_PATH=$( realpath "${repoName}/.." )
+        LOCAL_PACKAGE_REPOSITORY_ROOT="${repoName}"
+        echo "Using ABSOLUTE  path to repository $LOCAL_PACKAGE_REPOSITORY_ROOT"
+    else
+        # A relative path. Drop it local.
+        LOCAL_PACKAGE_REPOSITORY_PATH=$( realpath "${BUILD_DIR}/.." )
+        LOCAL_PACKAGE_REPOSITORY_ROOT="${LOCAL_PACKAGE_REPOSITORY_PATH}/${repoName}"
+        echo "Using RELATIVE path to repository $LOCAL_PACKAGE_REPOSITORY_ROOT"
+    fi
 
-    LOCAL_PACKAGE_REPOSITORY_DIR=$( realpath "${BUILD_DIR}/.." )
-    echo "Using path $LOCAL_PACKAGE_REPOSITORY_DIR"
-    LOCAL_PACKAGE_REPOSITORY_ROOT="${LOCAL_PACKAGE_REPOSITORY_DIR}/${repoName}"
 
     poolDir="${LOCAL_PACKAGE_REPOSITORY_ROOT}/pool"
     debsDir="${LOCAL_PACKAGE_REPOSITORY_ROOT}/debs"
@@ -607,13 +616,18 @@ function fxnDoDebianBuild()
     fi
     sudo apt-get update || fxnWARN "apt-get update failed. Continuing with local index."
 
-    fxnPP "Upgrading local packages so that any already installed build dependencies are up to date."
-    sudo apt-get upgrade --assume-yes || fxnWARN "apt-get upgrade failed. Continuing with local index."
+    fxnPP "Upgrading local packages so that any already installed build dependencies are up to date. Keeping existing config files."
+    # stick with existing configurations if asked. Not entirely sure this is good in all cases.
+    export DEBIAN_FRONTEND=noninteractive
+    sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade \
+         -o Dpkg::Options::="--force-confdef" \
+         -o Dpkg::Options::="--force-confold" \
+         --assume-yes || fxnWARN "apt-get upgrade failed. Continuing with local index."
 
     # Make sure the environment has the tools to configure the environment.
     if [ ! -e /usr/bin/mk-build-deps ];then
         fxnPP "Failed to find mk-build-deps. Installing devscripts and equivs."
-        fxnEC sudo apt-get install --assume-yes equivs devscripts || exit 1
+        fxnEC sudo DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes equivs devscripts || exit 1
     fi
 
 
@@ -622,6 +636,10 @@ function fxnDoDebianBuild()
     # remove the .deb after to keep git from FREAKING OUT!
     sudo mk-build-deps --install --remove ./debian/control --tool "apt-get -y"
     errorCode="$?"
+    if [ "$errorCode" = "25" ];then
+        fxnWARN "mk-build-deps finds no dependencies? Well, let's see where this goes...."
+        errorCode=0
+    fi
     if [ "$errorCode" != "0" ];then
         #note that an error was hit in case it's not a lack of dependencies.
         fxnERR "Hit error [ $errorCode ] in : sudo mk-build-deps --install ./debian/control --tool apt-get -y"


### PR DESCRIPTION
This adds duebuild-readme.md files for common-templates and debian-packages. ONIE will probably get updated next
Cleans up online help for duebuild scripts, providing examples of build invocation cases
Adds fixes for debian package duebuild:
  Support absolute path to reference a local package repository
  Keep existing package configuration during package upgrade
  Do not error out if no dependencies have to be installed.