### PR TITLE
Source only upload,  1 git repo

### DIFF
--- a/debian/README.source
+++ b/debian/README.source
@@ -1,0 +1,3 @@
+
+This package is `Architecture: all`, so it most be source-only uploaded.
+See https://wiki.debian.org/SourceOnlyUpload for "Why" and "How".

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+due (2.0.0-3) unstable; urgency=medium
+
+  * Three times should be a charm, closes: #961371.
+
+ -- Geert Stappers <stappers@debian.org>  Sun, 27 Sep 2020 10:45:53 +0200
+
 due (2.0.0-2) unstable; urgency=medium
 
   * Source only upload, to allow migrate to testing.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+due (2.0.0-2) unstable; urgency=medium
+
+  * Source only upload, to allow migrate to testing.
+  * Mention of the correct ITP, closes: #963171.
+  * Consolidation of git repositories.
+
+ -- Geert Stappers <stappers@debian.org>  Sun, 27 Sep 2020 09:43:19 +0200
+
 due (2.0.0-1) unstable; urgency=medium
 
   [ Alex Doyle ]

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 10),
 Standards-Version: 4.5.0
 Homepage: https://github.com/CumulusNetworks/DUE
 Vcs-Browser: https://github.com/CumulusNetworks/DUE/tree/debian/master
-Vcs-Git: https://github.com/ehdoyle/DUE.git -b debian/master
+Vcs-Git: https://github.com/CumulusNetworks/DUE.git -b debian/master
 
 Package: due
 Architecture: all


### PR DESCRIPTION
Packages of architecture all do need to be build by the buildds.
That is done by a  source only upload. Documented in d/README.source
The extra upload should close the correct Intent To Package.

Only one git repository to maintain.