### PR TITLE
Add container user to docker group if the container is being run to manipulate other Docker containers,

### DIFF
--- a/templates/common-templates/filesystem/usr/local/bin/container-create-user.sh
+++ b/templates/common-templates/filesystem/usr/local/bin/container-create-user.sh
@@ -182,7 +182,14 @@ function fxnAddUserInContainer()
             # Do not require password to become root via 'sudo su'
             echo "$USER_NAME       ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-
+            # If this container has Docker installed and will be using it.
+            if [ "$HOST_DOCKER_GID" != "" ];then
+                # Make sure the user a member of the docker group.
+                if grep -q "docker:" /etc/group ; then
+                    fxnPP "| Adding user to docker group "
+                    fxnEC adduser "$USER_NAME" docker > /dev/null || exit 1
+                fi
+            fi
 
             if [ -e /etc/due-bashrc ];then
                 echo "|___________________________________________________________________________|"


### PR DESCRIPTION
(Indicated by the HOST_DOCKER_GID value being set so that the group
ID of Docker in the container matches the GID on the host), then
the new user should be a member of the docker group, so that they
may use docker without having to be root, which will allow generated
files and workflows inside the container to match what would happen
outside the container.

There's probably a bigger question of just mapping all of the user's
host GIDs to the container environment, since right now only:
 - the user's primary group (needed for accurately mapping ownership of
    container created files to the host),
and
 - the docker group ( to avoid being root )

...but that can wait until there's a use case for it.

Signed-off-by:  Alex Doyle <adoyle@nvidia.com>