### PR TITLE
New file:   debian/.gitignore

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,7 @@
+# git, please ignore these generated files:
+.debhelper/
+.gitignore
+debhelper-build-stamp
+due.substvars
+due/
+files


### PR DESCRIPTION
To tell git it should ignore files generated during
build of the Debian package.