### PR TITLE
Pass arguments to docker build using --create --dockerarg 'args'

### DIFF
--- a/docs/due.1
+++ b/docs/due.1
@@ -302,6 +302,18 @@ Optional:
 .B \[en]prompt [prompt]
 Set in container prompt to [prompt] to provide user context
 .TP
+.B \[en]dockerarg [argument]
+Pass arguments to docker build.
+Argument is passed as a single value, so if it contains spaces, it
+should be quoted.
+\[en]dockerarg can be used multiple times, or can contain multiple
+strings.
+.PD 0
+.P
+.PD
+Example: \[en]dockerarg `\[en]build\-arg
+HTTP_PROXY=http://10.20.30.2:1234'
+.TP
 .B \[en]no\-image
 With \[en]create, allow directories to be created, but do not try to
 build the image.

--- a/docs/manpage-due-1.md
+++ b/docs/manpage-due-1.md
@@ -261,6 +261,13 @@ Optional:
 --prompt [prompt]
 :	Set in container prompt to [prompt] to provide user context
 
+--dockerarg [argument]
+:	Pass arguments to docker build. Argument is passed as a single
+	value, so if it contains spaces, it should be quoted.
+	--dockerarg can be used multiple times, or can contain multiple strings.  
+	Example: --dockerarg '--build-arg HTTP_PROXY=http://10.20.30.2:1234' 
+	
+
 --no-image
 :   With --create, allow directories to be created, but do not try
     to build the image. Effectively stops use of --dir.

--- a/due
+++ b/due
@@ -238,6 +238,8 @@ function fxnHelpCreate()
     echo "  2 - Build a Docker image from the image build directory."
     echo ""
     echo "   --build-dir <dirname>       Build using an existing configuration directory."
+    echo "   --dockerarg <arg>           Pass <arg> to the Docker build invocation."
+    echo "                               Use multiple times for multiple args, or pass one long quoted string."	
     echo ""
     echo "   --clean                      Remove due-build-merge directory."
     echo "   --help                       This help."
@@ -273,6 +275,12 @@ function fxnHelpCreateExamples()
     echo ""
     echo " Ex: filter creation examples to only show those containing 'foo' "
     echo " $0 --create --help --filter foo"
+    echo ""
+	echo " Ex: pass proxy arguments to Docker build, using --create and --dockerarg:"
+	echo " $0  --create --from debian:10 --description 'Debian 10 example' --name example-debian-10 \\ "
+	echo "     --prompt Ex --tag example-debian-10 --use-template example \\ "
+	echo "     --dockerarg '--build-arg HTTP_PROXY=http://10.20.30.2:1234' \\ "
+	echo "     --dockerarg ' --build-arg FTP_PROXY=http://40.50.60.5:4567' \\ "
     echo ""
 }
 
@@ -584,6 +592,12 @@ function fxnParseCreateArgs()
                     fxnERR "--tag Docker image tag [ $DOCKER_IMAGE_TAG ]must be lower case only."
                     exit 1
                 fi
+                shift
+                ;;
+            --dockerarg )
+                # Append addtional argument to pass through to docker build
+				# $2 should be passed as a quoted string
+                DOCKER_SPECIFIC_BUILD_ARGS+=" $2 "
                 shift
                 ;;
 

--- a/libdue
+++ b/libdue
@@ -37,6 +37,9 @@ FILTER_SHOW_ONLY_DUE="TRUE"
 # default tag to latest
 DOCKER_IMAGE_TAG="latest"
 
+# Options passed to Docker build, using --dockerarg
+DOCKER_SPECIFIC_BUILD_ARGS=""
+
 # List of example images
 KNOWN_IMAGES="
  debian:10
@@ -486,6 +489,9 @@ function fxnMakeNewDockerImage()
     local imageFrom="$1"
     local imageName="$2"
 
+	# Store the build command to be run, so it can be printed out to the user
+	local dockerBuildCommand=""
+	
     if [ "$2" = "" ];then
         # 3rd argument is optional
         fxnERR "Failed to pass enough arguments to fxnMakeNewDockerImage(). Exiting."
@@ -696,7 +702,10 @@ function fxnMakeNewDockerImage()
         if [ "$DO_CREATE_IMAGE_NOW" = "TRUE" ];then
             # Create it all in one shot
             fxnHeader "Creating the new image with: $0 --create --build-dir ${BUILD_MERGE_DIR}/$imageName"
-            $0 --create --build-dir "${BUILD_MERGE_DIR}/$imageName" --tag "$DOCKER_IMAGE_TAG"
+            $0 --create \
+			   --build-dir "${BUILD_MERGE_DIR}/$imageName" \
+			   --tag "$DOCKER_IMAGE_TAG" \
+			   --dockerarg "$DOCKER_SPECIFIC_BUILD_ARGS"
         else
             fxnHeader " To create the new image, run: $0 --create --build-dir ${BUILD_MERGE_DIR}/$imageName"
         fi
@@ -742,7 +751,17 @@ function fxnMakeNewDockerImage()
         #
         # Create the image based off the contents of ./$imageName
         # This allows the user to test incremental changes without starting from scratch.
-        fxnEC ${DOCKER_APP} build --no-cache=true --tag "${CONFIGURED_NAME_AND_TAG}" --file=./Dockerfile.create . || exit 1
+		dockerBuildCommand="${DOCKER_APP} build \
+			  --no-cache=true \
+			  $DOCKER_SPECIFIC_BUILD_ARGS \
+			  --tag "${CONFIGURED_NAME_AND_TAG}" \
+			  --file=./Dockerfile.create \
+			  ."
+		# Print the build command, turning all whitespace in to one space.
+		fxnHeader "Building with: $( echo $dockerBuildCommand | sed -e 's/[[:space:]]\+/ /g')"
+
+		# Run it.
+        fxnEC $dockerBuildCommand ||  exit 1
     fi
 
     # Done.


### PR DESCRIPTION
This creates a way to pass values to the 'docker build' command that
ultimately gets run to create the container. The specific instance
that demonstrated the need for this feature was the lack of a way to
pass Docker PROXY values to 'docker build'
So to achieve:
 docker build \
 --build-arg HTTP_PROXY=http://10.20.30.2:1234 \
 --build-arg FTP_PROXY=http://40.50.60.5:4567

One can now invoke DUE's --create  with
 --dockerarg "--build-arg HTTP_PROXY=http://10.20.30.2:1234"
 --dockerarg " --build-arg FTP_PROXY=http://40.50.60.5:4567"
OR
 --dockerarg "--build-arg HTTP_PROXY=http://10.20.30.2:1234 \
  --build-arg FTP_PROXY=http://40.50.60.5:4567"

Whatever follows --dockerarg is treated as a single argument, but
is passed to Docker unquoted for expansion.

Thanks to Billie Alsup at Cisco for pointing this out.

Signed-off-by: Alex Doyle <adoyle@nvidia.com>