### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Priority: optional
 Rules-Requires-Root: no
 Build-Depends: debhelper-compat (= 13),
 	       git
-Standards-Version: 4.6.0
+Standards-Version: 4.6.2
 Homepage: https://github.com/CumulusNetworks/DUE
 Vcs-Browser: https://github.com/CumulusNetworks/DUE/tree/debian/master
 Vcs-Git: https://github.com/CumulusNetworks/DUE.git -b debian/master

--- a/debian/due.lintian-overrides
+++ b/debian/due.lintian-overrides
@@ -3,12 +3,12 @@
 # a false positive, a `bash` script gets syntax check with `sh -n` ( but the
 #   templates/common-templates/filesystem/usr/local/bin/duebuild: 31: Syntax error: "(" unexpected
 # can be avoided )
-due: shell-script-fails-syntax-check usr/share/due/templates/common-templates/filesystem/usr/local/bin/duebuild
+due: shell-script-fails-syntax-check [usr/share/due/templates/common-templates/filesystem/usr/local/bin/duebuild]
 
 # The usr directory at the end is used by the template for the install path in the container,
 # and is not present on the host system, creating a false positive error.
-due: repeated-path-segment usr usr/share/due/templates/common-templates/filesystem/usr/
-due: repeated-path-segment usr usr/share/due/templates/debian-package/filesystem/usr/
-due: repeated-path-segment usr usr/share/due/templates/frr/filesystem/usr/
-due: repeated-path-segment usr usr/share/due/templates/onie/filesystem/usr/
+due: repeated-path-segment usr [usr/share/due/templates/common-templates/filesystem/usr/]
+due: repeated-path-segment usr [usr/share/due/templates/debian-package/filesystem/usr/]
+due: repeated-path-segment usr [usr/share/due/templates/frr/filesystem/usr/]
+due: repeated-path-segment usr [usr/share/due/templates/onie/filesystem/usr/]
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Bug-Database: https://github.com/CumulusNetworks/DUE/issues
+Bug-Submit: https://github.com/CumulusNetworks/DUE/issues/new
+Repository-Browse: https://github.com/CumulusNetworks/DUE


### PR DESCRIPTION
Fix some issues reported by lintian

* Update lintian override info format in d/due.lintian-overrides on line 6, 10-13. ([mismatched-override](https://lintian.debian.org/tags/mismatched-override))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/82a5fe53-3405-4233-8427-594f665c33b8/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/82a5fe53-3405-4233-8427-594f665c33b8/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/82a5fe53-3405-4233-8427-594f665c33b8/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/due/82a5fe53-3405-4233-8427-594f665c33b8.