### PR TITLE
container-create-user.sh - Replace login with runuser for better compatibility

### DIFF
--- a/templates/common-templates/filesystem/usr/local/bin/container-create-user.sh
+++ b/templates/common-templates/filesystem/usr/local/bin/container-create-user.sh
@@ -435,8 +435,8 @@ function fxnRunAsUser()
                 ;;
 
             'Debian' )
-                # Log in interactively with no password as new user
-                login -p -f  "${USER_NAME}"
+                # Start the shell as a login shell with an env similar to a real login
+                runuser -l "${USER_NAME}"
                 ;;
 
             * )


### PR DESCRIPTION
Using `runuser` fixes the interactive login on Debian 13 based containers.

When `login -p -f ${USERNAME}` is executed by container-create-user.sh, the process is stopped by SIGTTOU after attempted call of TCSETS. Debugging `login` in D12 showed that it was using a different call - SNDCTL_TMR_START about which strace is not fully certain reporting it as "SNDCTL_TMR_START or TCSETS". The likely reason that this was a bug in earlier versions of login fixed in the version included in D13. TCSETS (now, when used properly) is subject to job control leading to the `login` process being stopped by SIGTTOU.

runuser doesn't have the complex session and terminal handling that login does and is currently the recommended way to run commands as other users without requiring authentication. runuser has been available since Debian 8, so backward compatibility is preserved.

Tested with Debian 10, 12 and 13 based containers, verifying that initial container shell successfully starts and it is possible to start additional shells with `due --login`. Also compared the output of `set` in login-based and runuser-based shells: the latter miss HUSHLOGIN, MAIL, MOTD_SHOWN; these env vars do not seem to be critical for build environments.